### PR TITLE
Further improvements after #23 

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -17,7 +17,6 @@ services:
     command: gunicorn -b 0.0.0.0:8080 --access-logfile - -w 1 yarnitor:app
     environment:
       REDIS_ENDPOINT: "redis:6379"
-      YARN_ENDPOINT: "http://yarn:8088"
       YARN_POLL_SLEEP: 15
 
   # background collector

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,10 +18,6 @@ services:
     command: gunicorn -b 0.0.0.0:8080 --access-logfile - -w 5 yarnitor:app
     environment:
       REDIS_ENDPOINT: "redis:6379"
-      # This is the url to your yarn nodemanager.
-      # You must set it when you run docker compose.
-      # eg: http://yarn-application-master.mydomain:8088/
-      YARN_ENDPOINT:
       YARN_POLL_SLEEP: 15
     restart: always
 

--- a/yarnitor/api.py
+++ b/yarnitor/api.py
@@ -22,7 +22,8 @@ def status():
     ym = get_model()
     return jsonify({
         'status': 'ok',
-        'refresh_datetime': ym.refresh_datetime()
+        'refresh_datetime': ym.refresh_datetime(),
+        'current_rm': ym.current_rm()
     })
 
 

--- a/yarnitor/background/worker.py
+++ b/yarnitor/background/worker.py
@@ -6,7 +6,7 @@ is a Spark application or MapReduce application. Requires the following
 environment variables to configure itself.
 
 YARN_ENDPOINT
-    host:port for yarn api
+    HTTP host and port for one or more comma-separated YARN ResourceManager APIs
 YARN_POLL_SLEEP
     time to sleep between polling in seconds
 REDIS_ENDPOINT

--- a/yarnitor/background/worker.py
+++ b/yarnitor/background/worker.py
@@ -93,6 +93,15 @@ class YARNHandler(object):
             'version': version
         }
 
+    def current_rm(self):
+        """Gets the URL of the YARN RM last queried, successfully or not.
+
+        Returns
+        -------
+        str
+        """
+        return self.base_url['host']
+
     def get_url(self, path, **params):
         """Issues an HTTP GET to the given path with the given parameters
         and treats the response as JSON.
@@ -413,7 +422,7 @@ class YARNPoller(object):
         self.redis_client = redis_client
         self.yarn_handler = yarn_handler
         self.application_handlers = {}
-        self.state = {"current": {}, "cluster-metrics": {}}
+        self.state = {"application-metrics": {}, "cluster-metrics": {}}
 
     def register_handler(self, application_type, handler_class):
         """Registers a BaseHandler class to handle fetching progress details
@@ -533,8 +542,10 @@ class YARNPoller(object):
         in redis as a JSON string for retrieval by the frontend.
         """
         logger.info("Updating metrics from YARN")
-        self.state["current"] = self._generate_listing()
+        self.state["application-metrics"] = self._generate_listing()
         self.state["cluster-metrics"] = self.yarn_handler.cluster_metrics()
+        # Include the last queried cluster RM for UI purposes
+        self.state['current-rm'] = self.yarn_handler.current_rm()
         # Make the datetime conform to true ISO-8601 by adding Z(ulu) to indicate
         # this is truly a UTC time (without a timezone, the spec says it should be
         # treated as local time which is definitely NOT what we want)

--- a/yarnitor/core.py
+++ b/yarnitor/core.py
@@ -15,8 +15,6 @@ app.config["REDIS_URL"] = "redis://" + os.getenv("REDIS_ENDPOINT", "localhost:63
 app.config['BASE_URL'] = os.getenv('SCRIPT_NAME', '')
 # Interval between calls to fetch new data
 app.config['YARN_POLL_SLEEP'] = os.getenv('YARN_POLL_SLEEP', 15)
-# YARN web URL, used only to provide a link to the UI
-app.config['YARN_ENDPOINT'] = os.getenv('YARN_ENDPOINT', '#')
 
 # Register blueprints for APIs
 app.register_blueprint(api_bp)

--- a/yarnitor/model.py
+++ b/yarnitor/model.py
@@ -36,11 +36,20 @@ class YARNModel(object, metaclass=Singleton):
         """
         return self.state.get("refresh-datetime", '')
 
+    def current_rm(self):
+        """Gets the URL of the YARN RM last queried, successfully or not.
+
+        Returns
+        -------
+        str
+        """
+        return self.state.get("current-rm", '')
+
     def applications(self):
-        return self.state.get("current", {})
+        return self.state.get("application-metrics", {})
 
     def application_info(self, application_id):
-        return self.state.get("current", {}).get(application_id, {})
+        return self.state.get("application-metrics", {}).get(application_id, {})
 
     def cluster_metrics(self):
         metrics = self.state.get("cluster-metrics", {})

--- a/yarnitor/templates/index.html
+++ b/yarnitor/templates/index.html
@@ -45,7 +45,6 @@
         <script>
             var YARNITOR_BASE_URL = '{{ config["BASE_URL"] }}';
             var YARNITOR_REFRESH_INTERVAL_S = '{{ config["YARN_POLL_SLEEP"] }}';
-            var YARN_BASE_URL = '{{ config["YARN_ENDPOINT"] }}';
         </script>
     </head>
     <body>

--- a/yarnitor/templates/partials/progress.html
+++ b/yarnitor/templates/partials/progress.html
@@ -8,7 +8,7 @@
          aria-valuemax="{{ total }}"
          style="width: {{ completed_ratio }}%">
     </div>
-    <div class="progress-bar progress-bar-info progress-bar-striped active"
+    <div class="progress-bar progress-bar-info progress-bar-striped"
          role="progressbar"
          aria-valuenow="{{ running }}"
          aria-valuemin="0"


### PR DESCRIPTION
* Fix UI links to the YARN RM. Store the RM last queried in the backend status info and use that for the links.
* Disable progress animation. It turns CPUs into space heaters.